### PR TITLE
fix typo that fails build

### DIFF
--- a/Code/Chapter-1/test.cpp
+++ b/Code/Chapter-1/test.cpp
@@ -28,7 +28,7 @@ int main ( int argc, char * argv [] )
 	glm::vec2 d = a + 2.0f*c;
 	glm::vec2 e = -d;
 	glm::vec2 f = glm::normalize(e);
-	glm::vec2 a2(a.xy);
+	glm::vec2 a2(a.xy());
 	glm::vec2 b2(a.xy());
 	
 	float dot2 = glm::dot(glm::vec2(1), d);


### PR DESCRIPTION
It looks like a simple typo that generates an error during a build. 
gcc 11.2.0
glm 0.9.9.8

```
 error: invalid use of non-static member function ‘glm::vec<2, T, Q> glm::vec<2, T, Q>::xy() const [with T = float; glm::qualifier Q = glm::packed_highp]’
   31 |         glm::vec2 a2(a.xy);
      |                      ~~^~
```